### PR TITLE
BMP export

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ A web viewer for GTA2 graphics files (.sty) written from scratch in pure JS. Fea
 - Full support for these weird GTA2 virtual and physical palettes
 - Tiles viewer
     - Info about selected tile
+    - Exporting selected tile to an indexed-color BMP file
 - Sprites viewer
     - Detailed info about selected sprite
     - Previewing remaps
     - Searching sprites by their base and ID
+    - Exporting selected sprite to an indexed-color BMP file
 - Info about sprite bases (sprites count)
 - Cars viewer
     - Info about selected car's hitboxes, flags, traffic info, doors, etc.
@@ -23,7 +25,7 @@ A web viewer for GTA2 graphics files (.sty) written from scratch in pure JS. Fea
 
 ## To do
 - Editor
-- Exporing tiles/sprites/palettes
+- Exporing palettes
 - Virtual palettes list maybe?
 - ...
 

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
         <button id="tab_fonts_btn">Fonts</button>
     </div>
     <div id="tab_file" class="tab">
-        <h2>Javascript STY Viewer for GTA2 (BETA)</h2>
-        by masuo/izawartka<br><br>
+        <h2>Javascript STY Viewer for GTA2</h2>
+        by masuo/izawartka<br>
         STY File:<br>
         <input type="radio" id="filesrc_ex" name="filesrc" value="ex" checked>
         <label for="filesrc_ex">Example (bil.sty)</label><br>

--- a/js/bmp.js
+++ b/js/bmp.js
@@ -1,0 +1,43 @@
+export const BMP = {
+    save: (bitmap, filename) => {
+        const headersLength = 14 + 40;
+        const pixelDataLength = bitmap.data.length;
+        const paletteLength = bitmap.virtualPalette.physicalPalette.data.length;
+        const fileSize = headersLength + pixelDataLength + paletteLength;
+
+        const header = new Uint8Array([
+            0x42, 0x4D, // BM
+            ...new Uint8Array((new Uint32Array([fileSize])).buffer), // file size
+            0x00, 0x00, 0x00, 0x00, // reserved
+            ...new Uint8Array((new Uint32Array([headersLength + paletteLength])).buffer), // pixelData data offset
+            0x28, 0x00, 0x00, 0x00, // DIB header size
+            ...new Uint8Array((new Uint32Array([bitmap.width])).buffer), // Width
+            ...new Uint8Array((new Uint32Array([bitmap.height])).buffer), // Height
+            0x01, 0x00, // planes
+            0x08, 0x00, // bits per pixel
+            0x00, 0x00, 0x00, 0x00, // compression
+            0x00, 0x00, 0x00, 0x00, // image size (0 for uncompressed)
+            0x00, 0x00, 0x00, 0x00, // x pixels per meter
+            0x00, 0x00, 0x00, 0x00, // y pixels per meter
+            0x00, 0x01, 0x00, 0x00, // colors in color table (256)
+            0x00, 0x00, 0x00, 0x00, // important color count (256)
+        ]);
+
+        const palette = new Uint8Array(bitmap.virtualPalette.physicalPalette.getBGRAData());
+        
+        const lineMargin = new Array(bitmap.width % 4).fill(0);
+        let pixelLines = [];
+        for(let y = bitmap.height-1; y >= 0; y--) {
+            let line = [];
+            line = bitmap.data.slice(y*bitmap.width, (y+1)*bitmap.width);
+            pixelLines.push(...line, ...lineMargin);
+        }
+        const pixelData = new Uint8Array(pixelLines);
+
+        const file = new Blob([header, palette, pixelData], {type: 'image/bmp'});
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(file);
+        a.download = filename;
+        a.click();
+    }
+}

--- a/js/model/bitmap.js
+++ b/js/model/bitmap.js
@@ -16,10 +16,10 @@ export class OMBitmap {
                 imgData.data[i*4+3] = 0;
                 continue;
             }
-            imgData.data[i*4] = pixel[2];
+            imgData.data[i*4] = pixel[0];
             imgData.data[i*4+1] = pixel[1];
-            imgData.data[i*4+2] = pixel[0];
-            imgData.data[i*4+3] = 255-pixel[3];
+            imgData.data[i*4+2] = pixel[2];
+            imgData.data[i*4+3] = pixel[3];
         }
         return imgData;
     }

--- a/js/model/palette.js
+++ b/js/model/palette.js
@@ -10,8 +10,12 @@ export class OMPalette {
         return this.data.slice(i*4, i*4+4);
     }
 
-    getRGBAColor(i) {
-        let color = this.getColor(i);
-        return [color[2], color[1], color[0], 255-color[3]];
+    getBGRAData() {
+        let data = [];
+        for(let i = 0; i < 256; i++) {
+            let color = this.getColor(i);
+            data.push(color[2], color[1], color[0], color[3]);
+        }
+        return data;
     }
 }

--- a/js/pages/carspage.js
+++ b/js/pages/carspage.js
@@ -81,7 +81,7 @@ export class CarsPage {
         let remapsHTML = `<b>Remaps:</b><br><div class="wrapedlist">`;
         let remaps = this.selectedCar.remaps;
         remaps.forEach(remap => {
-            let color = remap.physicalPalette.getRGBAColor(80).join(', ');
+            let color = remap.physicalPalette.getColor(80).join(', ');
             remapsHTML += `<div class="remap" id="remap_${remap.relID}"><div class="remapsq" style="background-color: rgb(${color});"></div>${remap.relID}</div>`;
         });
         remapsHTML += '<div class="remap" id="remap_clear"><div class="remapsq remapcl"></div>clear</div></div>';

--- a/js/pages/palpage.js
+++ b/js/pages/palpage.js
@@ -68,7 +68,7 @@ export class PalPage {
     showColorDetails(colorPos) {
         if(!this.selectedPalette) return;
         this.renderer.renderPaletteSel(this.elements.selppalcanv, this.selectedPalette, colorPos);
-        let color = this.selectedPalette.getRGBAColor(colorPos);
+        let color = this.selectedPalette.getColor(colorPos);
         this.elements.selppalmove.innerHTML = 
             `<b>Index:</b> ${colorPos} / 
             <b>Color:</b> rgba(${color.join(', ')}) / 

--- a/js/pages/spritespage.js
+++ b/js/pages/spritespage.js
@@ -1,5 +1,6 @@
 import { spriteBases } from "../constants.js";
 import { Helper } from "../helper.js";
+import { BMP } from "../bmp.js";
 
 export class SpritesPage {
     constructor(elements, sty, renderer) {
@@ -24,7 +25,8 @@ export class SpritesPage {
             <b>Width:</b> ${sprite.bitmap.width} px<br>
             <b>Height:</b> ${sprite.bitmap.height} px<br>
             <b>Virtual palette:</b> sprite/${virtPal.relID}<br>
-            <b>Physical palette:</b> <input type="number" id="selspriteremap" value="${virtPal.physicalPalette.id}"><br>`;
+            <b>Physical palette:</b> <input type="number" id="selspriteremap" value="${virtPal.physicalPalette.id}"><br><br>
+            <button id="selspritesave">Download as BMP</button>`;
 
         this.elements.selspriteinfo.innerHTML = infoHTML;
 
@@ -33,6 +35,10 @@ export class SpritesPage {
             let paletteID = Helper.loopValue(0, this.sty.data.palettes.length - 1, e.target.value);
             let palette = this.sty.data.palettes[paletteID];
             this.renderer.renderBitmap(this.elements.selspritecanv, sprite.bitmap, palette);
+        }
+
+        document.getElementById('selspritesave').onclick = () => {
+            BMP.save(sprite.bitmap, `sprite_${sprite.base}_${sprite.relID}.bmp`);
         }
     }
 

--- a/js/pages/tilespage.js
+++ b/js/pages/tilespage.js
@@ -1,4 +1,6 @@
 import { materialNames } from "../constants.js";
+import { Helper } from "../helper.js";
+import { BMP } from "../bmp.js";
 
 export class TilesPage {
     constructor(elements, sty, renderer) {
@@ -8,17 +10,30 @@ export class TilesPage {
 
     select(tileID) {
         let tile = this.sty.data.tiles[tileID];
+        let virtPal = tile.bitmap.virtualPalette;
         this.renderer.renderBitmap(this.elements.seltilecanv, tile.bitmap);
 
         let infoHTML = `
             <b>Tile ID:</b> ${tileID}<br>
             <b>Page ID:</b> ${tile.pageID}<br>
             <b>Tile on page ID:</b> ${tile.relID}<br>
-            <b>Virtual palette:</b> tile/${tile.bitmap.virtualPalette.relID}<br>
-            <b>Physical palette:</b> ${tile.bitmap.virtualPalette.physicalPalette.id}<br>
-            <b>Material:</b> ${materialNames[tile.material] || ''}<br>`;
+            <b>Virtual palette:</b> tile/${virtPal.relID}<br>
+            <b>Physical palette:</b> <input type="number" id="seltileremap" value="${virtPal.physicalPalette.id}"><br>
+            <b>Material:</b> ${materialNames[tile.material] || ''}<br><br>
+            <button id="seltilesave">Download as BMP</button>`;
 
         this.elements.seltileinfo.innerHTML = infoHTML;
+
+        let remapInput = document.getElementById('seltileremap');
+        remapInput.oninput = (e) => {   
+            let paletteID = Helper.loopValue(0, this.sty.data.palettes.length - 1, e.target.value);
+            let palette = this.sty.data.palettes[paletteID];
+            this.renderer.renderBitmap(this.elements.seltilecanv, tile.bitmap, palette);
+        }
+
+        document.getElementById('seltilesave').onclick = () => {
+            BMP.save(tile.bitmap, `tile_${tileID}.bmp`);
+        }
     }
 
     render() {

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -284,11 +284,8 @@ export class Renderer {
         for(let i = 0; i < palettesCount; i++) {
             let pal = this.sty.data.palettes[i].data;
             let imgData = ctx.createImageData(1, 256);
-            for(let p = 0; p < 256*4; p+=4) {
-                imgData.data[p+0] = pal[p+2];
-                imgData.data[p+1] = pal[p+1];
-                imgData.data[p+2] = pal[p+0];
-                imgData.data[p+3] = 255-pal[p+3];
+            for(let p = 0; p < 256*4; p++) {
+                imgData.data[p] = pal[p];
             }
             for(let j = 0; j < xScale; j++)
                 ctx.putImageData(imgData, i*xScale+j, 0);
@@ -302,7 +299,7 @@ export class Renderer {
         const ctx = canvas.getContext('2d');
 
         for(let p = 0; p < 256; p++) {
-            let pixel = palette.getRGBAColor(p);
+            let pixel = palette.getColor(p);
             ctx.fillStyle = `rgba(${pixel.join(', ')})`;
             ctx.fillRect(p*scale, 0, scale, canvas.height);
         }

--- a/js/sty.js
+++ b/js/sty.js
@@ -72,6 +72,11 @@ export class STY {
         let palData = this.readPagedContent(PPAL, 256, 256, 4, 256);
         
         return palData.map((data) => {
+            for(let i = 0; i < 256; i++) {
+                [data.data[i*4], data.data[i*4+2]] = [data.data[i*4+2], data.data[i*4]];
+                data.data[i*4+3] = 255-data.data[i*4+3];
+            }
+
             return new OMPalette(
                 data.pageID,
                 data.relID,


### PR DESCRIPTION
+ added bility to export bitmaps (sprites and tiles) to color-indexed BMP files
+ tiles can now be remapped too
* physical palettes are now stored in memory as RGBA instead of BGRA
- removed "beta" from the header